### PR TITLE
fix: add users to Discord server during onboarding

### DIFF
--- a/app/api/onboarding/discord/callback/route.ts
+++ b/app/api/onboarding/discord/callback/route.ts
@@ -72,6 +72,19 @@ export async function GET(req: Request) {
     const email = String(me?.email || '').trim()
     if (!discordId) return redirectWithError(req, 'missing_discord_id')
 
+    const guildId = String(process.env.DISCORD_GUILD_ID || '').trim()
+    const botToken = String(process.env.DISCORD_BOT_TOKEN || '').trim()
+    if (guildId && botToken) {
+      await fetch(`https://discord.com/api/v10/guilds/${guildId}/members/${discordId}`, {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bot ${botToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ access_token: accessToken }),
+      })
+    }
+
     await updateOnboardingSession(ensured.sessionId, {
       discordId,
       discordUsername: username || null,

--- a/app/api/onboarding/discord/start/route.ts
+++ b/app/api/onboarding/discord/start/route.ts
@@ -41,7 +41,7 @@ export async function GET(req: Request) {
     authorizeUrl.searchParams.set('client_id', clientId)
     authorizeUrl.searchParams.set('response_type', 'code')
     authorizeUrl.searchParams.set('redirect_uri', redirectUri)
-    authorizeUrl.searchParams.set('scope', 'identify email')
+    authorizeUrl.searchParams.set('scope', 'identify email guilds.join')
     authorizeUrl.searchParams.set('state', oauthState)
 
     const res = NextResponse.redirect(authorizeUrl.toString())


### PR DESCRIPTION
The OAuth scope was missing guilds.join, and the callback only assigned
roles but never added the user to the guild. Users who hadn't manually
joined the server would silently fail role assignment.

Now the callback calls PUT /guilds/{id}/members/{userId} with the user's
access_token to add them to the server before attempting role assignment.

https://claude.ai/code/session_01RWKDBQJrMug8YmCEe1MVxr