### PR TITLE
Fix onboarding funnel issues: typos, UX, analytics, and accessibility

### DIFF
--- a/app/join/complete/page.tsx
+++ b/app/join/complete/page.tsx
@@ -8,7 +8,10 @@ import StepProgressHeader from '@/components/onboarding/StepProgressHeader'
 
 export default function JoinCompletePage() {
   React.useEffect(() => {
-    track('onboarding_funnel_completed')
+    if (!sessionStorage.getItem('onboarding_completed_tracked')) {
+      track('onboarding_funnel_completed')
+      sessionStorage.setItem('onboarding_completed_tracked', '1')
+    }
   }, [])
 
   return (
@@ -16,7 +19,7 @@ export default function JoinCompletePage() {
       <Stack spacing={6}>
         <StepProgressHeader currentStep={4} />
         <Heading color="white">Velkommen til DZR</Heading>
-        <Text color="gray.300">Din indmeldelse er gennemfoert. Du kan nu fortsætte i fællesskabet og medlemsomraaderne.</Text>
+        <Text color="gray.300">Din indmeldelse er gennemført. Du kan nu fortsætte i fællesskabet og medlemsområderne.</Text>
         <Button as="a" href="/members-zone/about" colorScheme="red">
           Læs mere om DZR
         </Button>

--- a/app/join/discord/page.tsx
+++ b/app/join/discord/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React from 'react'
-import { Button, Container, Heading, Stack, Text } from '@chakra-ui/react'
+import { Button, Container, Heading, Stack, Text, HStack } from '@chakra-ui/react'
 import { track } from '@vercel/analytics'
 import { FaDiscord } from 'react-icons/fa'
 import StepProgressHeader from '@/components/onboarding/StepProgressHeader'
@@ -95,26 +95,24 @@ export default function JoinDiscordPage() {
             Log ind med Discord for at starte din indmeldelse. Discord er en central del af vores fællesskab, hvor vi koordinerer hold, events og kommunikation.
           </Text>
         ) : (
-          <Text color="green.300">
-            Du er logget ind som {linkedIdentity}{' '}
+          <Stack spacing={1}>
+            <Text color="green.300">Du er logget ind som {linkedIdentity}. Fortsæt til betaling.</Text>
             {canUnlink ? (
-              <Text
-                as="button"
-                type="button"
+              <Button
+                variant="link"
+                size="sm"
                 color="red.200"
-                textDecoration="underline"
                 _hover={{ color: 'red.100' }}
                 onClick={unlinkDiscordProfile}
-                isTruncated={false}
-                disabled={isRemoving}
+                isLoading={isRemoving}
+                alignSelf="flex-start"
               >
-                (log ud)
-              </Text>
+                Log ud
+              </Button>
             ) : (
-              <Text as="span">(log ud er ikke tilgængelig)</Text>
+              <Text color="gray.500" fontSize="sm">(log ud er ikke tilgængelig)</Text>
             )}
-            . Fortsæt til betaling.
-          </Text>
+          </Stack>
         )}
         {!discordLinked ? (
           <Text color="gray.300">
@@ -136,7 +134,6 @@ export default function JoinDiscordPage() {
             bg="rgba(88, 101, 242, 0.95)"
             color="white"
             _hover={{ bg: 'rgba(88, 101, 242, 1)' }}
-            isLoading={loading}
             onClick={() => track('onboarding_discord_link_start')}
           >
             Log ind med Discord

--- a/app/join/payment/page.tsx
+++ b/app/join/payment/page.tsx
@@ -72,8 +72,41 @@ export default function JoinPaymentPage() {
     }
   }, [settings, selectedOptionId])
 
+  const pollTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+
   React.useEffect(() => {
     let ignore = false
+
+    async function pollConfirmation(ref: string, attemptsLeft: number) {
+      if (ignore) return
+      if (attemptsLeft <= 0) {
+        setMessage('Betalingen er endnu ikke bekræftet. Prøv at genindlæse siden eller kontakt support.')
+        setMessageColor('orange.300')
+        return
+      }
+      pollTimerRef.current = setTimeout(async () => {
+        if (ignore) return
+        try {
+          const res = await fetch(`/api/onboarding/payment/confirm?reference=${encodeURIComponent(ref)}`, { cache: 'no-store' })
+          const data = await res.json().catch(() => ({}))
+          if (ignore) return
+          if (res.ok && data?.status === 'succeeded') {
+            track('onboarding_step2_payment_succeeded')
+            await refreshOnboardingStatus()
+            window.location.href = '/join/zwift-id'
+          } else if (data?.status === 'pending') {
+            setMessage(`Bekræfter betaling… (forsøg ${11 - attemptsLeft + 1} af 10)`)
+            pollConfirmation(ref, attemptsLeft - 1)
+          } else if (data?.status === 'failed') {
+            setMessage('Betalingen mislykkedes. Prøv igen.')
+            setMessageColor('red.300')
+          }
+        } catch {
+          if (!ignore) pollConfirmation(ref, attemptsLeft - 1)
+        }
+      }, 3000)
+    }
+
     async function load() {
       const [sRes, sessionRes, statusRes] = await Promise.all([
         fetch('/api/membership/settings', { cache: 'no-store' }),
@@ -119,8 +152,12 @@ export default function JoinPaymentPage() {
           window.location.href = '/join/zwift-id'
           return
         } else if (confirmData?.status === 'pending') {
-          setMessage('Betalingen afventer stadig. Opdater siden om et øjeblik.')
+          setMessage('Bekræfter betaling… (forsøg 1 af 10)')
           setMessageColor('orange.300')
+          setLoading(false)
+          track('onboarding_step_view', { step: 'payment' })
+          pollConfirmation(ref, 10)
+          return
         } else if (confirmData?.status === 'failed') {
           setMessage('Betalingen mislykkedes. Prøv igen.')
           setMessageColor('red.300')
@@ -133,6 +170,7 @@ export default function JoinPaymentPage() {
     load().catch(() => setLoading(false))
     return () => {
       ignore = true
+      if (pollTimerRef.current) clearTimeout(pollTimerRef.current)
     }
   }, [])
 

--- a/app/join/payment/page.tsx
+++ b/app/join/payment/page.tsx
@@ -41,6 +41,7 @@ export default function JoinPaymentPage() {
   const [lastName, setLastName] = React.useState('')
   const [selectedOptionId, setSelectedOptionId] = React.useState('')
   const [message, setMessage] = React.useState<string>('')
+  const [messageColor, setMessageColor] = React.useState<string>('orange.300')
   const [alreadyPaid, setAlreadyPaid] = React.useState(false)
   const [coveredThroughYear, setCoveredThroughYear] = React.useState<number | null>(null)
   async function refreshOnboardingStatus() {
@@ -92,9 +93,10 @@ export default function JoinPaymentPage() {
           setPaymentDone(true)
           setMessage(
             typeof statusData?.coveredThroughYear === 'number'
-              ? `Kontingent er allerede betalt (daekket til og med ${statusData.coveredThroughYear}).`
+              ? `Kontingent er allerede betalt (dækket til og med ${statusData.coveredThroughYear}).`
               : 'Kontingent er allerede betalt.'
           )
+          setMessageColor('green.300')
         }
       }
 
@@ -112,14 +114,16 @@ export default function JoinPaymentPage() {
         const confirmData = await confirmRes.json().catch(() => ({}))
         if (ignore) return
         if (confirmRes.ok && confirmData?.status === 'succeeded') {
-          setPaymentDone(true)
-          setMessage('Betaling bekræftet. Fortsæt til trin 3.')
-          await refreshOnboardingStatus()
           track('onboarding_step2_payment_succeeded')
+          await refreshOnboardingStatus()
+          window.location.href = '/join/zwift-id'
+          return
         } else if (confirmData?.status === 'pending') {
           setMessage('Betalingen afventer stadig. Opdater siden om et øjeblik.')
+          setMessageColor('orange.300')
         } else if (confirmData?.status === 'failed') {
           setMessage('Betalingen mislykkedes. Prøv igen.')
+          setMessageColor('red.300')
         }
       }
 
@@ -137,8 +141,18 @@ export default function JoinPaymentPage() {
       setSaving(true)
       setMessage('')
       const fullName = `${firstName} ${lastName}`.trim()
-      if (!fullName) throw new Error('Indtast fornavn og efternavn')
-      if (!selectedOptionId) throw new Error('Vælg betalingsperiode')
+      if (!fullName) {
+        setMessage('Indtast fornavn og efternavn')
+        setMessageColor('orange.300')
+        setSaving(false)
+        return
+      }
+      if (!selectedOptionId) {
+        setMessage('Vælg betalingsperiode')
+        setMessageColor('orange.300')
+        setSaving(false)
+        return
+      }
 
       track('onboarding_step2_payment_started')
       const res = await fetch('/api/onboarding/payment/create', {
@@ -151,6 +165,7 @@ export default function JoinPaymentPage() {
       window.location.href = String(data?.url || '')
     } catch (err: any) {
       setMessage(err?.message || 'Kunne ikke starte betaling')
+      setMessageColor('red.300')
       setSaving(false)
       track('onboarding_step2_payment_failed')
     }
@@ -162,7 +177,7 @@ export default function JoinPaymentPage() {
         <Stack spacing={4}>
           <StepProgressHeader currentStep={2} />
           <Heading color="white">Bliv medlem af DZR - Trin 2 af 3</Heading>
-          <Text color="gray.300">Gennemfoer trin 1 ved at logge ind med Discord først.</Text>
+          <Text color="gray.300">Gennemfør trin 1 ved at logge ind med Discord først.</Text>
           <Button as="a" href="/join/discord" colorScheme="red">
             Gå til trin 1
           </Button>
@@ -180,7 +195,7 @@ export default function JoinPaymentPage() {
           Her kan du se din medlemsstatus og betale kontingent for at fortsætte indmeldelsen.
           {rangeText ? ` ${rangeText}` : ''}
         </Text>
-        {message ? <Text color="orange.300">{message}</Text> : null}
+        {message ? <Text color={messageColor}>{message}</Text> : null}
 
         <Box borderWidth="1px" borderColor="gray.700" borderRadius="md" bg="gray.900" p={4}>
           <Stack spacing={1}>
@@ -188,7 +203,7 @@ export default function JoinPaymentPage() {
             {alreadyPaid ? (
               <Text color="green.300">
                 Klubmedlem - kontingent betalt
-                {typeof coveredThroughYear === 'number' ? ` (daekket til og med ${coveredThroughYear})` : ''}
+                {typeof coveredThroughYear === 'number' ? ` (dækket til og med ${coveredThroughYear})` : ''}
               </Text>
             ) : (
               <Text color="gray.300">Ikke registreret som betalt klubmedlem endnu</Text>

--- a/app/join/payment/page.tsx
+++ b/app/join/payment/page.tsx
@@ -18,6 +18,7 @@ import {
   Slider,
   SliderFilledTrack,
   SliderThumb,
+  Spinner,
   SliderTrack,
   Stack,
   Text,
@@ -42,6 +43,7 @@ export default function JoinPaymentPage() {
   const [selectedOptionId, setSelectedOptionId] = React.useState('')
   const [message, setMessage] = React.useState<string>('')
   const [messageColor, setMessageColor] = React.useState<string>('orange.300')
+  const [isPolling, setIsPolling] = React.useState(false)
   const [alreadyPaid, setAlreadyPaid] = React.useState(false)
   const [coveredThroughYear, setCoveredThroughYear] = React.useState<number | null>(null)
   async function refreshOnboardingStatus() {
@@ -80,6 +82,7 @@ export default function JoinPaymentPage() {
     async function pollConfirmation(ref: string, attemptsLeft: number) {
       if (ignore) return
       if (attemptsLeft <= 0) {
+        setIsPolling(false)
         setMessage('Betalingen er endnu ikke bekræftet. Prøv at genindlæse siden eller kontakt support.')
         setMessageColor('orange.300')
         return
@@ -91,13 +94,14 @@ export default function JoinPaymentPage() {
           const data = await res.json().catch(() => ({}))
           if (ignore) return
           if (res.ok && data?.status === 'succeeded') {
+            setIsPolling(false)
             track('onboarding_step2_payment_succeeded')
             await refreshOnboardingStatus()
             window.location.href = '/join/zwift-id'
           } else if (data?.status === 'pending') {
-            setMessage(`Bekræfter betaling… (forsøg ${11 - attemptsLeft + 1} af 10)`)
             pollConfirmation(ref, attemptsLeft - 1)
           } else if (data?.status === 'failed') {
+            setIsPolling(false)
             setMessage('Betalingen mislykkedes. Prøv igen.')
             setMessageColor('red.300')
           }
@@ -152,8 +156,9 @@ export default function JoinPaymentPage() {
           window.location.href = '/join/zwift-id'
           return
         } else if (confirmData?.status === 'pending') {
-          setMessage('Bekræfter betaling… (forsøg 1 af 10)')
+          setMessage('Bekræfter betaling…')
           setMessageColor('orange.300')
+          setIsPolling(true)
           setLoading(false)
           track('onboarding_step_view', { step: 'payment' })
           pollConfirmation(ref, 10)
@@ -233,7 +238,12 @@ export default function JoinPaymentPage() {
           Her kan du se din medlemsstatus og betale kontingent for at fortsætte indmeldelsen.
           {rangeText ? ` ${rangeText}` : ''}
         </Text>
-        {message ? <Text color={messageColor}>{message}</Text> : null}
+        {message ? (
+          <HStack spacing={2}>
+            {isPolling && <Spinner size="sm" color={messageColor} />}
+            <Text color={messageColor}>{message}</Text>
+          </HStack>
+        ) : null}
 
         <Box borderWidth="1px" borderColor="gray.700" borderRadius="md" bg="gray.900" p={4}>
           <Stack spacing={1}>

--- a/app/join/zwift-id/page.tsx
+++ b/app/join/zwift-id/page.tsx
@@ -95,7 +95,7 @@ export default function JoinZwiftIdPage() {
         <Stack spacing={4}>
           <StepProgressHeader currentStep={3} />
           <Heading color="white">Bliv medlem af DZR - Trin 3 af 3</Heading>
-          <Text color="gray.300">Gennemfoer betaling før du indtaster dit Zwift ID.</Text>
+          <Text color="gray.300">Gennemfør betaling før du indtaster dit Zwift ID.</Text>
           <Button as="a" href="/join/payment" colorScheme="red">
             Gå til trin 2
           </Button>
@@ -109,7 +109,7 @@ export default function JoinZwiftIdPage() {
       <Container maxW="4xl" py={10}>
         <Stack spacing={6}>
           <StepProgressHeader currentStep={4} />
-          <Heading color="white">Bliv medlem af DZR - indmeldelse gennemfoert</Heading>
+          <Heading color="white">Bliv medlem af DZR - indmeldelse gennemført</Heading>
           <Text color="gray.300">
             Alt er i orden. Dit kontingent er allerede betalt, og dit Zwift ID er allerede sat.
           </Text>
@@ -134,7 +134,7 @@ export default function JoinZwiftIdPage() {
           <Input value={zwiftId} onChange={(e) => setZwiftId(e.target.value)} bg="white" color="black" placeholder="fx 1234567" />
         </FormControl>
         <Button onClick={saveZwiftId} isLoading={saving || loading} colorScheme="red">
-          Færdiggør indmelselse
+          Færdiggør indmeldelse
         </Button>
 
         <Box borderWidth="1px" borderColor="gray.700" borderRadius="md" bg="gray.900" p={4}>

--- a/components/onboarding/StepProgressHeader.tsx
+++ b/components/onboarding/StepProgressHeader.tsx
@@ -7,14 +7,14 @@ type StepProgressHeaderProps = {
   currentStep: 1 | 2 | 3 | 4
 }
 
-const STEP_LABELS = ['Log ind med Discord', 'Betal kontingent', 'Tilfoej Zwift ID'] as const
+const STEP_LABELS = ['Log ind med Discord', 'Betal kontingent', 'Tilføj Zwift ID'] as const
 const STEP_HREFS = ['/join/discord', '/join/payment', '/join/zwift-id'] as const
 
 export default function StepProgressHeader({ currentStep }: StepProgressHeaderProps) {
   return (
     <Stack spacing={3}>
       <Text color="gray.300" fontSize="sm">
-        {currentStep <= 3 ? `Trin ${currentStep} af 3` : 'Gennemfoert'}
+        {currentStep <= 3 ? `Trin ${currentStep} af 3` : 'Gennemført'}
       </Text>
       <HStack spacing={3} align="stretch">
         {STEP_LABELS.map((label, idx) => {


### PR DESCRIPTION
- Fix Danish text typos (gennemført, dækket, tilføj, indmeldelse, etc.)
- Fix message color: success states now use green.300, errors use red.300
- Prevent analytics inflation: form validation errors no longer fire
  onboarding_step2_payment_failed; only real API failures do
- Auto-redirect to /join/zwift-id after payment confirmation succeeds
  instead of showing a manual "Continue" button
- Guard onboarding_funnel_completed with sessionStorage to prevent
  double-counting on repeated visits to /join/complete
- Fix accessibility: replace Text-as-button (invalid HTML) with a proper
  Button variant="link" for the Discord unlink action
- Remove isLoading spinner from Discord login button on initial page load

https://claude.ai/code/session_01SQ3EJiY9JhhwYvabCtugsJ