### PR TITLE
Redesign /join landing page with 4-zone layout

### DIFF
--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -1,13 +1,84 @@
 'use client'
 
 import React from 'react'
-import { Badge, Box, Button, Container, Heading, List, ListItem, Stack, Text } from '@chakra-ui/react'
-import { FaDiscord } from 'react-icons/fa'
+import {
+  Badge,
+  Box,
+  Button,
+  Circle,
+  Container,
+  Divider,
+  Flex,
+  Heading,
+  HStack,
+  Icon,
+  SimpleGrid,
+  Stack,
+  Text,
+  VStack,
+  keyframes,
+} from '@chakra-ui/react'
+import { FaDiscord, FaRoad, FaUsers } from 'react-icons/fa'
+import { FaTrophy } from 'react-icons/fa6'
+import { MdCardMembership, MdDirectionsBike, MdHowToVote, MdPayment } from 'react-icons/md'
+import { IconType } from 'react-icons'
+
+const pulseShadow = keyframes`
+  0%   { box-shadow: 0 0 0 0 rgba(173, 26, 45, 0.7); }
+  70%  { box-shadow: 0 0 0 18px rgba(173, 26, 45, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(173, 26, 45, 0); }
+`
 
 type SettingsResponse = { minAmountDkk?: number; maxAmountDkk?: number }
 
+interface BenefitCardProps {
+  icon: IconType
+  heading: string
+  text: string
+}
+
+function BenefitCard({ icon, heading, text }: BenefitCardProps) {
+  return (
+    <Box
+      bg="gray.900"
+      borderRadius="md"
+      borderTop="2px solid #ad1a2d"
+      p={4}
+    >
+      <Icon as={icon} boxSize={6} color="#ad1a2d" mb={2} />
+      <Text color="white" fontWeight="semibold" fontSize="sm" mb={1}>
+        {heading}
+      </Text>
+      <Text color="gray.400" fontSize="sm">
+        {text}
+      </Text>
+    </Box>
+  )
+}
+
+interface StepProps {
+  number: number
+  icon: IconType
+  label: string
+}
+
+function Step({ number, icon, label }: StepProps) {
+  return (
+    <VStack spacing={2} flex={1}>
+      <Circle size="40px" bg="#ad1a2d" color="white" fontWeight="bold" fontSize="lg">
+        {number}
+      </Circle>
+      <Icon as={icon} boxSize={7} color="gray.300" />
+      <Text color="gray.300" fontSize="sm" textAlign="center">
+        {label}
+      </Text>
+    </VStack>
+  )
+}
+
 export default function JoinIndexPage() {
-  const [kontingentText, setKontingentText] = React.useState<string>('Kontingentet fastsættes i indmeldelsesflowet.')
+  const [kontingentText, setKontingentText] = React.useState<string>('Valgfrit beløb')
+  const [kontingentRange, setKontingentRange] = React.useState<string | null>(null)
 
   React.useEffect(() => {
     let ignore = false
@@ -22,7 +93,8 @@ export default function JoinIndexPage() {
         const min = Number(data?.minAmountDkk)
         const max = Number(data?.maxAmountDkk)
         if (Number.isFinite(min) && Number.isFinite(max)) {
-          setKontingentText(`Kontingentet er valgfrit mellem ${min} og ${max} DKK.`)
+          setKontingentText(`${min}–${max} DKK`)
+          setKontingentRange(`Kontingentet er valgfrit mellem ${min} og ${max} DKK.`)
         }
       } catch {
         // Keep fallback text when settings cannot be loaded.
@@ -30,14 +102,14 @@ export default function JoinIndexPage() {
     }
 
     loadSettings()
-    return () => {
-      ignore = true
-    }
+    return () => { ignore = true }
   }, [])
 
   return (
     <Container maxW="5xl" py={{ base: 8, md: 14 }}>
-      <Stack spacing={8}>
+      <Stack spacing={12}>
+
+        {/* Zone 1 — Hero */}
         <Box textAlign="center">
           <Badge bg="#ad1a2d" color="white" px={3} py={1} borderRadius="full" mb={4}>
             Bliv medlem af DZR
@@ -50,41 +122,79 @@ export default function JoinIndexPage() {
           </Text>
         </Box>
 
+        {/* Zone 2 — Benefit Cards */}
+        <Box>
+          <Heading size="sm" mb={4} textTransform="uppercase" letterSpacing="wider" color="gray.400">
+            Hvad får du som klubmedlem?
+          </Heading>
+          <SimpleGrid columns={{ base: 1, sm: 2, md: 3 }} spacing={4}>
+            <BenefitCard icon={FaUsers} heading="DZR fællesskab" text="Adgang til fællesskab og klubaktiviteter" />
+            <BenefitCard icon={FaTrophy} heading="Løb & holdmiljø" text="Deltagelse i organiserede løb og holdmiljø" />
+            <BenefitCard icon={MdCardMembership} heading="DCU e-licens" text="Mulighed for DCU e-licens via DZR" />
+            <BenefitCard icon={FaRoad} heading="DCU Forårsliga" text="Adgang til DCU Forårsliga som del af klubsetup" />
+            <BenefitCard icon={MdHowToVote} heading="Stemmeret" text="Stemmeret på DZRs generalforsamling" />
+          </SimpleGrid>
+        </Box>
+
+        {/* Zone 3 — 3-step visual stepper */}
         <Box borderWidth="1px" borderColor="gray.700" borderRadius="lg" bg="gray.900" p={{ base: 5, md: 8 }}>
-          <Stack spacing={5}>
-            <Heading color="white" size="md">
-              Hvad får du som klubmedlem?
-            </Heading>
-            <List spacing={2} color="gray.200">
-              <ListItem>• Adgang til DZR fællesskab og aktiviteter</ListItem>
-              <ListItem>• Deltagelse i vores organiserede løb og holdmiljø</ListItem>
-              <ListItem>• Mulighed for DCU e-licens via DZR</ListItem>
-              <ListItem>• Adgang til DCU Forårsliga som del af vores klubsetup</ListItem>
-              <ListItem>• Stemmeret på generalforsamlingen</ListItem>
-            </List>
-            <Text color="gray.300">
-              Indmeldelsen foregår i 3 enkle trin: log ind med Discord, betal kontingent, og indtast dit Zwift ID.
-            </Text>
-            <Text color="gray.300">{kontingentText}</Text>
-            <Text color="gray.300">
-              Discord er en central del af DZR-fællesskabet, hvor vi koordinerer hold, events og kommunikation.
-              Derfor bruger vi Discord-login i indmeldelsesflowet.
-            </Text>
-            <Text color="gray.300">
-              Har du ikke en Discord-konto endnu, kan du oprette en gratis konto i forbindelse med login.
-            </Text>
+          <Heading size="sm" mb={6} textTransform="uppercase" letterSpacing="wider" color="gray.400">
+            Sådan foregår det — 3 enkle trin
+          </Heading>
+          <Flex
+            direction={{ base: 'column', md: 'row' }}
+            align={{ base: 'flex-start', md: 'center' }}
+            gap={{ base: 6, md: 0 }}
+          >
+            <Step number={1} icon={FaDiscord} label="Log ind med Discord" />
+            <Divider
+              display={{ base: 'none', md: 'block' }}
+              borderColor="gray.600"
+              borderStyle="dashed"
+            />
+            <Step number={2} icon={MdPayment} label="Betal kontingent" />
+            <Divider
+              display={{ base: 'none', md: 'block' }}
+              borderColor="gray.600"
+              borderStyle="dashed"
+            />
+            <Step number={3} icon={MdDirectionsBike} label="Indtast dit Zwift ID" />
+          </Flex>
+          <Text color="gray.400" fontSize="sm" mt={6}>
+            Discord er en central del af DZR-fællesskabet, hvor vi koordinerer hold, events og kommunikation.
+            Har du ikke en Discord-konto endnu, kan du oprette en gratis konto i forbindelse med login.
+          </Text>
+        </Box>
+
+        {/* Zone 4 — Price + CTA */}
+        <Box borderWidth="1px" borderColor="gray.600" borderRadius="lg" bg="gray.900" p={{ base: 5, md: 8 }}>
+          <Stack spacing={4}>
+            <HStack spacing={2}>
+              <Icon as={MdPayment} color="green.300" boxSize={5} />
+              <Text color="green.300" fontWeight="semibold">
+                Kontingent: {kontingentText}
+              </Text>
+            </HStack>
+            {kontingentRange && (
+              <Text color="gray.400" fontSize="sm">{kontingentRange}</Text>
+            )}
             <Button
               as="a"
               href="/join/discord"
               colorScheme="red"
               size="lg"
               leftIcon={<FaDiscord />}
-              alignSelf="flex-start"
+              animation={`${pulseShadow} 2s infinite`}
+              w="full"
             >
               Start indmeldelse
             </Button>
+            <Text color="gray.500" fontSize="xs" textAlign="center">
+              3 hurtige trin · Discord-konto kræves · Gratis at oprette
+            </Text>
           </Stack>
         </Box>
+
       </Stack>
     </Container>
   )

--- a/app/members-zone/about/page.tsx
+++ b/app/members-zone/about/page.tsx
@@ -1,34 +1,35 @@
 'use client';
 
 import React from 'react';
-import { useSession, signIn } from 'next-auth/react';
+import { useSession } from 'next-auth/react';
 import {
+  Accordion,
+  AccordionButton,
+  AccordionIcon,
+  AccordionItem,
+  AccordionPanel,
+  Badge,
   Box,
-  Container,
-  Heading,
-  Text,
-  Stack,
-  Divider,
-  SimpleGrid,
+  Button,
   Card,
   CardBody,
   CardHeader,
-  VStack,
+  Container,
+  Divider,
+  Heading,
   HStack,
-  Badge,
-  Accordion,
-  AccordionItem,
-  AccordionButton,
-  AccordionPanel,
-  AccordionIcon,
+  Icon,
   List,
   ListItem,
-  ListIcon,
-  Button,
+  SimpleGrid,
+  Stack,
+  Text,
+  VStack,
 } from '@chakra-ui/react';
-import { MdCheckCircle, MdPerson } from 'react-icons/md';
 import { FaDiscord } from 'react-icons/fa';
+import { FaTrophy } from 'react-icons/fa6';
 import { FiArrowRight } from 'react-icons/fi';
+import { MdDirectionsBike, MdPerson } from 'react-icons/md';
 import LoadingSpinnerMemb from '@/components/LoadingSpinnerMemb';
 
 interface BoardMember {
@@ -38,7 +39,7 @@ interface BoardMember {
 }
 
 export default function AboutPage() {
-  const { data: session, status } = useSession();
+  const { status } = useSession();
   const [membershipSettings, setMembershipSettings] = React.useState<{ minAmountDkk: number; maxAmountDkk: number } | null>(null);
 
   React.useEffect(() => {
@@ -49,11 +50,11 @@ export default function AboutPage() {
           const data = await res.json();
           setMembershipSettings({
             minAmountDkk: data?.minAmountDkk ?? 10,
-            maxAmountDkk: data?.maxAmountDkk ?? 100
+            maxAmountDkk: data?.maxAmountDkk ?? 100,
           });
         }
-      } catch (error) {
-        console.error('Failed to fetch membership settings:', error);
+      } catch {
+        // keep defaults
       }
     }
     fetchSettings();
@@ -63,7 +64,6 @@ export default function AboutPage() {
     return <LoadingSpinnerMemb />;
   }
 
-  // Board members data
   const boardMembers: BoardMember[] = [
     { name: 'Christian Kjær', role: 'Formand (Chairman)' },
     { name: 'Nick Niebling', role: 'Kasserer (Treasurer)' },
@@ -76,132 +76,208 @@ export default function AboutPage() {
 
   return (
     <Container maxW="7xl" py={8}>
-      <VStack spacing={8} align="stretch">
-        {/* Header */}
+      <VStack spacing={12} align="stretch">
+
+        {/* Zone 1 — Hero */}
         <Box textAlign="center">
+          <Badge bg="#ad1a2d" color="white" px={3} py={1} borderRadius="full" mb={4}>
+            Bliv med i DZR
+          </Badge>
           <Heading color="white" size="2xl" mb={4}>
-            About DZR
+            Race. Træn. Fællesskab.
           </Heading>
-          <Text color="gray.300" fontSize="lg">
-            Learn more about Danish Zwift Racers
+          <Text color="gray.300" fontSize={{ base: 'md', md: 'lg' }} maxW="3xl" mx="auto">
+            DZR er en almennyttig online cykelforening med fællesskab, træning og løb for ryttere i hele Danmark.
+            Bliv en del af det voksende e-cykelfællesskab.
           </Text>
         </Box>
 
-        <Divider borderColor="gray.600" />
+        {/* Zone 2 — Three benefit pillars */}
+        <SimpleGrid columns={{ base: 1, md: 3 }} spacing={4}>
+          <Box bg="gray.900" borderRadius="md" borderTop="2px solid #ad1a2d" p={5}>
+            <Icon as={FaTrophy} boxSize={6} color="#ad1a2d" mb={2} />
+            <Heading size="sm" color="white" mb={1}>Løb & Racing</Heading>
+            <Text color="gray.400" fontSize="sm">Organiserede løb, DCU Forårsliga og holdmiljø på Zwift</Text>
+          </Box>
+          <Box bg="gray.900" borderRadius="md" borderTop="2px solid #ad1a2d" p={5}>
+            <Icon as={FaDiscord} boxSize={6} color="#ad1a2d" mb={2} />
+            <Heading size="sm" color="white" mb={1}>Discord Fællesskab</Heading>
+            <Text color="gray.400" fontSize="sm">Aktiv community med koordinering af hold, events og kommunikation</Text>
+          </Box>
+          <Box bg="gray.900" borderRadius="md" borderTop="2px solid #ad1a2d" p={5}>
+            <Icon as={MdDirectionsBike} boxSize={6} color="#ad1a2d" mb={2} />
+            <Heading size="sm" color="white" mb={1}>Træning</Heading>
+            <Text color="gray.400" fontSize="sm">Strukturerede træningspas og zone 2-workouts for alle niveauer</Text>
+          </Box>
+        </SimpleGrid>
 
-        {/* General Information Section */}
-        <Box>
-          <Heading color="white" size="lg" mb={4}>
-            General Information
-          </Heading>
-          <Card bg="gray.900" borderColor="gray.700" borderWidth="1px">
+        {/* Zone 3 — Auth-aware CTA */}
+        <Box borderWidth="1px" borderColor="gray.700" borderRadius="lg" bg="gray.900" p={{ base: 5, md: 8 }}>
+          {status === 'authenticated' ? (
+            <Stack direction={{ base: 'column', sm: 'row' }} spacing={4}>
+              <Button
+                as="a"
+                href="/members-zone/my-pages"
+                bg="#ad1a2d"
+                color="white"
+                _hover={{ bg: '#8a1524' }}
+                size="lg"
+                py={7}
+                borderRadius="0"
+                textTransform="uppercase"
+                letterSpacing="wide"
+                fontSize="md"
+                rightIcon={<FiArrowRight size="1.2em" />}
+              >
+                Gå til Min Side
+              </Button>
+              <Button
+                as="a"
+                href="/members-zone"
+                variant="outline"
+                color="white"
+                borderColor="gray.500"
+                _hover={{ bg: 'gray.800' }}
+                size="lg"
+                py={7}
+                borderRadius="0"
+                textTransform="uppercase"
+                letterSpacing="wide"
+                fontSize="md"
+              >
+                Members Zone
+              </Button>
+            </Stack>
+          ) : (
+            <Stack direction={{ base: 'column', sm: 'row' }} spacing={4}>
+              <Button
+                as="a"
+                href="/join"
+                bg="#ad1a2d"
+                color="white"
+                _hover={{ bg: '#8a1524' }}
+                size="lg"
+                py={7}
+                borderRadius="0"
+                textTransform="uppercase"
+                letterSpacing="wide"
+                fontSize="md"
+                rightIcon={<FiArrowRight size="1.2em" />}
+              >
+                Start indmeldelse
+              </Button>
+              <Button
+                as="a"
+                href="https://discord.gg/FBtCsddbmU"
+                target="_blank"
+                bg="rgba(88, 101, 242, 0.95)"
+                color="white"
+                _hover={{ bg: '#4752C4' }}
+                size="lg"
+                py={7}
+                borderRadius="0"
+                textTransform="uppercase"
+                letterSpacing="wide"
+                fontSize="md"
+                leftIcon={<FaDiscord size="1.2em" />}
+              >
+                Prøv Community (gratis)
+              </Button>
+            </Stack>
+          )}
+        </Box>
+
+        {/* Zone 4 — Membership tier cards (info-only) */}
+        <SimpleGrid columns={{ base: 1, md: 2 }} spacing={4}>
+          <Card bg="gray.800" borderColor="#ad1a2d" borderWidth="2px" h="full" overflow="hidden">
+            <CardHeader>
+              <Heading size="md" color="white">Klub Medlem</Heading>
+              <Badge bg="#ad1a2d" color="white" mt={2}>{membershipAmount}</Badge>
+            </CardHeader>
             <CardBody>
-              <VStack align="start" spacing={4}>
-                <Text color="white" fontSize="md" lineHeight="tall">
-                  Danish Zwift Racers (DZR) er en almennyttig og non-profit online sportsforening med medlemmer fra hele Danmark.
-                  Foreningen blev stiftet den 17. november 2025 med det formål at fremme e-cykling som sportsgren og socialt fællesskab i Danmark.
-                </Text>
-                <Text color="white" fontSize="md" lineHeight="tall">
-                  DZR skaber rammer for træning, løb og fællesskab på virtuelle cykelplatforme.
-                  Aktiviteter foregår primært online, men fysiske møder kan afholdes efter behov.
-                  Foreningen er medlem af Danmarks Cykle Union (DCU).
-                </Text>
+              <List spacing={2} color="white">
+                <ListItem fontSize="sm">• Deltager i Discord-server</ListItem>
+                <ListItem fontSize="sm">• Online fællesskab</ListItem>
+                <ListItem fontSize="sm">• Betalt kontingent</ListItem>
+                <ListItem fontSize="sm">• Stemmeret på generalforsamling</ListItem>
+                <ListItem fontSize="sm">• Mulighed for DCU e-licens via DZR</ListItem>
+                <ListItem fontSize="sm">• Støt DZR 🫶</ListItem>
+              </List>
+            </CardBody>
+          </Card>
 
-                <Text color="gray.400" fontSize="sm">
-                  CVR: 46035771
-                </Text>
+          <Card bg="gray.800" borderColor="#5865F2" borderWidth="2px" h="full" overflow="hidden">
+            <CardHeader>
+              <Heading size="md" color="white">Community Medlem</Heading>
+              <Badge bg="#5865F2" color="white" mt={2}>Gratis</Badge>
+            </CardHeader>
+            <CardBody>
+              <List spacing={2} color="white">
+                <ListItem fontSize="sm">• Deltager i Discord-server</ListItem>
+                <ListItem fontSize="sm">• Online fællesskab</ListItem>
+                <ListItem fontSize="sm">• Gratis</ListItem>
+                <ListItem fontSize="sm">• Ingen stemmeret</ListItem>
+              </List>
+            </CardBody>
+          </Card>
+        </SimpleGrid>
 
-                <Divider borderColor="gray.600" my={2} />
+        {/* Zone 5 — Organisatoriske oplysninger & vedtægter (collapsed) */}
+        <Accordion allowToggle>
+          <AccordionItem borderWidth="1px" borderColor="gray.700" borderRadius="lg" overflow="hidden">
+            <h2>
+              <AccordionButton bg="gray.900" _hover={{ bg: 'gray.800' }} py={4} px={6}>
+                <Box flex="1" textAlign="left" color="white" fontWeight="semibold">
+                  Organisatoriske oplysninger & vedtægter
+                </Box>
+                <AccordionIcon color="white" />
+              </AccordionButton>
+            </h2>
+            <AccordionPanel bg="gray.900" px={6} pb={8}>
+              <VStack align="stretch" spacing={6} mt={2}>
 
-                <Heading color="white" size="md" mt={4}>
-                  Medlemskategorier
-                </Heading>
-                <SimpleGrid columns={{ base: 1, md: 2 }} spacing={4} mt={4}>
-                  <Card bg="gray.800" borderColor="#ad1a2d" borderWidth="2px" h="full" overflow="hidden">
-                    <CardHeader>
-                      <Heading size="md" color="white">
-                        Klub Medlem
-                      </Heading>
-                      <Badge bg="#ad1a2d" color="white" mt={2}>
-                        {membershipAmount}
-                      </Badge>
-                    </CardHeader>
-                    <CardBody display="flex" flexDirection="column" justifyContent="space-between">
-                      <List spacing={2} color="white">
-                        <ListItem fontSize="sm">
-                          • Deltager i Discord-server
-                        </ListItem>
-                        <ListItem fontSize="sm">
-                          • Online fællesskab
-                        </ListItem>
-                        <ListItem fontSize="sm">
-                          • Betalt kontingent
-                        </ListItem>
-                        <ListItem fontSize="sm">
-                          • Stemmeret på generalforsamling
-                        </ListItem>
-                        <ListItem fontSize="sm">
-                          • Mulighed for DCU e-licens via DZR
-                        </ListItem>
-                        <ListItem fontSize="sm">
-                          • Støt DZR 🫶
-                        </ListItem>
-                      </List>
+                {/* Org info */}
+                <Box>
+                  <Text color="white" fontSize="md" lineHeight="tall" mb={3}>
+                    Danish Zwift Racers (DZR) er en almennyttig og non-profit online sportsforening med medlemmer fra hele Danmark.
+                    Foreningen blev stiftet den 17. november 2025 med det formål at fremme e-cykling som sportsgren og socialt fællesskab i Danmark.
+                  </Text>
+                  <Text color="white" fontSize="md" lineHeight="tall" mb={3}>
+                    DZR skaber rammer for træning, løb og fællesskab på virtuelle cykelplatforme.
+                    Aktiviteter foregår primært online, men fysiske møder kan afholdes efter behov.
+                    Foreningen er medlem af Danmarks Cykle Union (DCU).
+                  </Text>
+                  <Text color="gray.400" fontSize="sm">CVR: 46035771</Text>
+                </Box>
 
-                      {status === 'unauthenticated' ? (
-                        <Text mt={6} fontSize="xs" color="gray.400" textAlign="center" pb={2}>
-                          For at blive Klub Medlem skal du først være Community Medlem på Discord.
-                        </Text>
-                      ) : (
-                        <Text mt={6} fontSize="xs" color="gray.400" textAlign="center" pb={2}>
-                          Gå til Min Side for at betale kontingent og blive Klub Medlem.
-                        </Text>
-                      )}
-                    </CardBody>
-                    {status === 'unauthenticated' ? (
-                      <Button onClick={() => signIn('discord')} bg="#ad1a2d" color="white" _hover={{ bg: '#8a1524' }} w="full" size="lg" py={7} borderRadius="0" textTransform="uppercase" letterSpacing="wide" fontSize="md" leftIcon={<FaDiscord size="1.2em" />}>
-                        Log ind med Discord
-                      </Button>
-                    ) : (
-                      <Button as="a" href="/members-zone/my-pages" bg="#ad1a2d" color="white" _hover={{ bg: '#8a1524' }} w="full" size="lg" py={7} borderRadius="0" textTransform="uppercase" letterSpacing="wide" fontSize="md" rightIcon={<FiArrowRight size="1.2em" />}>
-                        Gå til Min Side
-                      </Button>
-                    )}
-                  </Card>
+                <Divider borderColor="gray.700" />
 
-                  <Card bg="gray.800" borderColor="#5865F2" borderWidth="2px" h="full" overflow="hidden">
-                    <CardHeader>
-                      <Heading size="md" color="white">
-                        Community Medlem
-                      </Heading>
-                      <Badge bg="#5865F2" color="white" mt={2}>
-                        Gratis
-                      </Badge>
-                    </CardHeader>
-                    <CardBody display="flex" flexDirection="column" justifyContent="space-between">
-                      <List spacing={2} color="white">
-                        <ListItem fontSize="sm">
-                          • Deltager i Discord-server
-                        </ListItem>
-                        <ListItem fontSize="sm">
-                          • Online fællesskab
-                        </ListItem>
-                        <ListItem fontSize="sm">
-                          • Gratis
-                        </ListItem>
-                        <ListItem fontSize="sm">
-                          • Ingen stemmeret
-                        </ListItem>
-                      </List>
-                    </CardBody>
-                    <Button as="a" href="https://discord.gg/FBtCsddbmU" target="_blank" bg="#5865F2" color="white" _hover={{ bg: '#4752C4' }} w="full" size="lg" py={7} borderRadius="0" textTransform="uppercase" letterSpacing="wide" fontSize="md" leftIcon={<FaDiscord size="1.2em" />}>
-                      Join Discord Server
-                    </Button>
-                  </Card>
-                </SimpleGrid>
+                {/* Board members */}
+                <Box>
+                  <Heading size="sm" color="gray.400" mb={4} textTransform="uppercase" letterSpacing="wider">
+                    Bestyrelse
+                  </Heading>
+                  <SimpleGrid columns={{ base: 1, md: 3 }} spacing={3}>
+                    {boardMembers.map((member, index) => (
+                      <Box key={index} bg="gray.800" borderWidth="1px" borderColor="gray.700" borderRadius="md" p={3}>
+                        <HStack mb={1}>
+                          <MdPerson color="white" size={16} />
+                          <Text color="white" fontWeight="semibold" fontSize="sm">{member.name}</Text>
+                        </HStack>
+                        <Text color="gray.400" fontSize="xs">{member.role}</Text>
+                        {member.email && (
+                          <Text color="blue.400" fontSize="xs" mt={1}>{member.email}</Text>
+                        )}
+                      </Box>
+                    ))}
+                  </SimpleGrid>
+                  <Text color="gray.500" mt={3} fontSize="xs">Kontakt bestyrelsen via Discord</Text>
+                </Box>
 
-                {/* Terms and Conditions - Compact */}
-                <Box borderWidth="1px" borderColor="gray.600" borderRadius="md" bg="gray.800" mt={4}>
+                <Divider borderColor="gray.700" />
+
+                {/* Terms */}
+                <Box borderWidth="1px" borderColor="gray.600" borderRadius="md" bg="gray.800">
                   <Accordion allowToggle>
                     <AccordionItem border="none">
                       <h2>
@@ -213,393 +289,302 @@ export default function AboutPage() {
                         </AccordionButton>
                       </h2>
                       <AccordionPanel pb={3} pt={1} color="gray.300" fontSize="xs" lineHeight="tall">
-                        <Text mb={2}>
-                          Ved betaling af kontingent accepterer du følgende vilkår:
-                        </Text>
+                        <Text mb={2}>Ved betaling af kontingent accepterer du følgende vilkår:</Text>
                         <List spacing={1} ml={4}>
-                          <ListItem>
-                            • Medlemskabet gælder for den valgte periode og refunderes ikke ved opsigelse i denne periode
-                          </ListItem>
-                          <ListItem>
-                            • Medlemskabet udløber automatisk ved periodens afslutning uden yderligere forpligtelser
-                          </ListItem>
-                          <ListItem>
-                            • Betalt kontingent refunderes ikke, jf. foreningens vedtægter §5
-                          </ListItem>
-                          <ListItem>
-                            • Medlemskabet fornyes ikke automatisk - du skal selv forny dit medlemskab ved periodens udløb
-                          </ListItem>
-                          <ListItem>
-                            • Som klubmedlem har du stemmeret på generalforsamlinger
-                          </ListItem>
+                          <ListItem>• Medlemskabet gælder for den valgte periode og refunderes ikke ved opsigelse i denne periode</ListItem>
+                          <ListItem>• Medlemskabet udløber automatisk ved periodens afslutning uden yderligere forpligtelser</ListItem>
+                          <ListItem>• Betalt kontingent refunderes ikke, jf. foreningens vedtægter §5</ListItem>
+                          <ListItem>• Medlemskabet fornyes ikke automatisk - du skal selv forny dit medlemskab ved periodens udløb</ListItem>
+                          <ListItem>• Som klubmedlem har du stemmeret på generalforsamlinger</ListItem>
                         </List>
                       </AccordionPanel>
                     </AccordionItem>
                   </Accordion>
                 </Box>
 
-                <Divider borderColor="gray.600" my={2} />
+                <Divider borderColor="gray.700" />
 
-              </VStack>
-            </CardBody>
-          </Card>
-        </Box>
+                {/* Vedtægter */}
+                <Box>
+                  <Heading size="sm" color="gray.400" mb={4} textTransform="uppercase" letterSpacing="wider">
+                    Vedtægter
+                  </Heading>
+                  <Card bg="gray.800" borderColor="gray.700" borderWidth="1px">
+                    <CardBody>
+                      <Accordion allowToggle>
+                        <AccordionItem border="none">
+                          <h2>
+                            <AccordionButton _hover={{ bg: 'gray.800' }}>
+                              <Box flex="1" textAlign="left" color="white" fontWeight="bold">§1 - Navn og hjemsted</Box>
+                              <AccordionIcon color="white" />
+                            </AccordionButton>
+                          </h2>
+                          <AccordionPanel pb={4} color="gray.300">
+                            <Text>
+                              Foreningens navn er Danish Zwift Racers (DZR). Foreningen er en almennyttig
+                              og non-profit online sportsforening med hjemsted på Frederiksberg og med medlemmer fra hele Danmark. Foreningen
+                              har CVR-nummer 46035771.
+                            </Text>
+                          </AccordionPanel>
+                        </AccordionItem>
 
-        {/* Board Members Section */}
-        <Box>
-          <Heading color="white" size="lg" mb={4}>
-            Board Members
-          </Heading>
-          <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} spacing={4}>
-            {boardMembers.map((member, index) => (
-              <Card key={index} bg="gray.900" borderColor="gray.700" borderWidth="1px">
-                <CardBody>
-                  <VStack align="start" spacing={2}>
-                    <HStack>
-                      <MdPerson color="white" size={24} />
-                      <Heading size="md" color="white">
-                        {member.name}
-                      </Heading>
-                    </HStack>
-                    <Text color="gray.400" fontWeight="bold">
-                      {member.role}
-                    </Text>
-                    {member.email && (
-                      <Text color="blue.400" fontSize="sm">
-                        {member.email}
+                        <AccordionItem border="none" borderTop="1px" borderColor="gray.700">
+                          <h2>
+                            <AccordionButton _hover={{ bg: 'gray.800' }}>
+                              <Box flex="1" textAlign="left" color="white" fontWeight="bold">§2 - Formål</Box>
+                              <AccordionIcon color="white" />
+                            </AccordionButton>
+                          </h2>
+                          <AccordionPanel pb={4} color="gray.300">
+                            <Text mb={2}>
+                              Foreningens formål er at fremme e-cykling som sportsgren og socialt
+                              fællesskab i Danmark. DZR skaber rammer for træning, løb og fællesskab
+                              på virtuelle cykelplatforme.
+                            </Text>
+                            <Text>Aktiviteter foregår primært online, men fysiske møder kan afholdes efter behov.</Text>
+                          </AccordionPanel>
+                        </AccordionItem>
+
+                        <AccordionItem border="none" borderTop="1px" borderColor="gray.700">
+                          <h2>
+                            <AccordionButton _hover={{ bg: 'gray.800' }}>
+                              <Box flex="1" textAlign="left" color="white" fontWeight="bold">§3 - Tilknytning</Box>
+                              <AccordionIcon color="white" />
+                            </AccordionButton>
+                          </h2>
+                          <AccordionPanel pb={4} color="gray.300">
+                            <Text mb={2}>
+                              Foreningen er medlem af Danmarks Cykle Union (DCU) og
+                              følger DCU&apos;s love og bestemmelser.
+                            </Text>
+                            <Text>Foreningen har ingen øvrige organisatoriske tilknytninger.</Text>
+                          </AccordionPanel>
+                        </AccordionItem>
+
+                        <AccordionItem border="none" borderTop="1px" borderColor="gray.700">
+                          <h2>
+                            <AccordionButton _hover={{ bg: 'gray.800' }}>
+                              <Box flex="1" textAlign="left" color="white" fontWeight="bold">§4 - Medlemskab</Box>
+                              <AccordionIcon color="white" />
+                            </AccordionButton>
+                          </h2>
+                          <AccordionPanel pb={4} color="gray.300">
+                            <Text mb={2}>
+                              Som medlem kan optages enhver person, der støtter foreningens formål.
+                              Indmeldelse sker digitalt via foreningens officielle hjemmeside
+                              www.dzrracingseries.com.
+                            </Text>
+                            <Text mb={2}>Der sondres mellem to medlemskategorier:</Text>
+                            <List spacing={2} ml={4}>
+                              <ListItem>
+                                <strong>1. Klub medlemmer:</strong> har betalt kontingent, har stemmeret
+                                og mulighed for DCU e-licens via DZR.
+                              </ListItem>
+                              <ListItem>
+                                <strong>2. Community medlemmer:</strong> deltager i foreningens
+                                Discord-server og online fællesskab, men uden stemmeret eller adgang til
+                                DCU-aktiviteter.
+                              </ListItem>
+                            </List>
+                            <Text mt={2}>Medlemskab er gyldigt, når kontingentet er betalt via foreningens hjemmeside.</Text>
+                          </AccordionPanel>
+                        </AccordionItem>
+
+                        <AccordionItem border="none" borderTop="1px" borderColor="gray.700">
+                          <h2>
+                            <AccordionButton _hover={{ bg: 'gray.800' }}>
+                              <Box flex="1" textAlign="left" color="white" fontWeight="bold">§5 - Udmeldelse og eksklusion</Box>
+                              <AccordionIcon color="white" />
+                            </AccordionButton>
+                          </h2>
+                          <AccordionPanel pb={4} color="gray.300">
+                            <Text mb={2}>
+                              Udmeldelse sker digitalt via foreningens hjemmeside www.dzrracingseries.com.
+                              Betalt kontingent refunderes ikke.
+                            </Text>
+                            <Text>
+                              Et medlem kan ekskluderes, hvis det handler til skade for foreningen.
+                              Eksklusion kan indbringes for den førstkommende generalforsamling til
+                              endelig afgørelse.
+                            </Text>
+                          </AccordionPanel>
+                        </AccordionItem>
+
+                        <AccordionItem border="none" borderTop="1px" borderColor="gray.700">
+                          <h2>
+                            <AccordionButton _hover={{ bg: 'gray.800' }}>
+                              <Box flex="1" textAlign="left" color="white" fontWeight="bold">§6 - Kontingent</Box>
+                              <AccordionIcon color="white" />
+                            </AccordionButton>
+                          </h2>
+                          <AccordionPanel pb={4} color="gray.300">
+                            <Text mb={2}>
+                              Kontingentets størrelse fastsættes én gang årligt på generalforsamlingen.
+                              Kontingent opkræves digitalt for et år ad gangen.
+                            </Text>
+                            <Text>
+                              Kontingentet dækker perioden 1. januar til 31. december og følger
+                              DCU&apos;s licensår.
+                            </Text>
+                          </AccordionPanel>
+                        </AccordionItem>
+
+                        <AccordionItem border="none" borderTop="1px" borderColor="gray.700">
+                          <h2>
+                            <AccordionButton _hover={{ bg: 'gray.800' }}>
+                              <Box flex="1" textAlign="left" color="white" fontWeight="bold">§7 - Generalforsamling</Box>
+                              <AccordionIcon color="white" />
+                            </AccordionButton>
+                          </h2>
+                          <AccordionPanel pb={4} color="gray.300">
+                            <Text mb={2}>
+                              Generalforsamlingen er foreningens højeste myndighed. Ordinær
+                              generalforsamling afholdes én gang årligt - digitalt eller fysisk -
+                              inden udgangen af marts.
+                            </Text>
+                            <Text mb={2}>Indkaldelse sker med mindst 14 dages varsel via e-mail og Discord.</Text>
+                            <Text mb={2} fontWeight="bold">Dagsorden:</Text>
+                            <List spacing={1} ml={4}>
+                              <ListItem>1. Valg af dirigent</ListItem>
+                              <ListItem>2. Bestyrelsens beretning</ListItem>
+                              <ListItem>3. Godkendelse af regnskab</ListItem>
+                              <ListItem>4. Fastsættelse af kontingent og budget</ListItem>
+                              <ListItem>5. Indkomne forslag</ListItem>
+                              <ListItem>6. Valg af bestyrelse</ListItem>
+                              <ListItem>7. Valg af revisor</ListItem>
+                              <ListItem>8. Eventuelt</ListItem>
+                            </List>
+                            <Text mt={2}>
+                              Forslag skal være bestyrelsen i hænde senest 7 dage før. Hvert aktivt
+                              medlem har én stemme. Beslutninger træffes ved simpelt flertal.
+                            </Text>
+                          </AccordionPanel>
+                        </AccordionItem>
+
+                        <AccordionItem border="none" borderTop="1px" borderColor="gray.700">
+                          <h2>
+                            <AccordionButton _hover={{ bg: 'gray.800' }}>
+                              <Box flex="1" textAlign="left" color="white" fontWeight="bold">§8 - Ekstraordinær generalforsamling</Box>
+                              <AccordionIcon color="white" />
+                            </AccordionButton>
+                          </h2>
+                          <AccordionPanel pb={4} color="gray.300">
+                            <Text>
+                              Afholdes når bestyrelsen beslutter det, eller når mindst 1/5 af de aktive
+                              medlemmer (Klub medlemmer) skriftligt kræver det. Indkaldes med samme varsel som ordinær
+                              generalforsamling.
+                            </Text>
+                          </AccordionPanel>
+                        </AccordionItem>
+
+                        <AccordionItem border="none" borderTop="1px" borderColor="gray.700">
+                          <h2>
+                            <AccordionButton _hover={{ bg: 'gray.800' }}>
+                              <Box flex="1" textAlign="left" color="white" fontWeight="bold">§9 - Bestyrelsen</Box>
+                              <AccordionIcon color="white" />
+                            </AccordionButton>
+                          </h2>
+                          <AccordionPanel pb={4} color="gray.300">
+                            <Text mb={2}>
+                              Bestyrelsen består af mindst 3 medlemmer valgt for ét år ad gangen.
+                              Bestyrelsen konstituerer sig selv med formand, kasserer og menigt medlem.
+                            </Text>
+                            <Text mb={2}>
+                              Møder kan afholdes digitalt. Bestyrelsen er beslutningsdygtig, når mindst
+                              halvdelen af medlemmerne deltager.
+                            </Text>
+                            <Text>Beslutninger træffes ved simpelt flertal.</Text>
+                          </AccordionPanel>
+                        </AccordionItem>
+
+                        <AccordionItem border="none" borderTop="1px" borderColor="gray.700">
+                          <h2>
+                            <AccordionButton _hover={{ bg: 'gray.800' }}>
+                              <Box flex="1" textAlign="left" color="white" fontWeight="bold">§10 - Økonomi og hæftelse</Box>
+                              <AccordionIcon color="white" />
+                            </AccordionButton>
+                          </h2>
+                          <AccordionPanel pb={4} color="gray.300">
+                            <Text mb={2}>
+                              Foreningens regnskabsår følger kalenderåret. Foreningen tegnes af formanden
+                              og kassereren i forening.
+                            </Text>
+                            <Text mb={2}>
+                              Medlemmer hæfter ikke personligt for foreningens forpligtelser - foreningen
+                              hæfter alene med sin egen formue.
+                            </Text>
+                            <Text>Regnskabet revideres af en kritisk revisor valgt af generalforsamlingen.</Text>
+                          </AccordionPanel>
+                        </AccordionItem>
+
+                        <AccordionItem border="none" borderTop="1px" borderColor="gray.700">
+                          <h2>
+                            <AccordionButton _hover={{ bg: 'gray.800' }}>
+                              <Box flex="1" textAlign="left" color="white" fontWeight="bold">§11 - Vedtægtsændringer</Box>
+                              <AccordionIcon color="white" />
+                            </AccordionButton>
+                          </h2>
+                          <AccordionPanel pb={4} color="gray.300">
+                            <Text>
+                              Ændringer af vedtægterne kræver, at 2/3 af de afgivne stemmer på en
+                              generalforsamling stemmer for.
+                            </Text>
+                          </AccordionPanel>
+                        </AccordionItem>
+
+                        <AccordionItem border="none" borderTop="1px" borderColor="gray.700">
+                          <h2>
+                            <AccordionButton _hover={{ bg: 'gray.800' }}>
+                              <Box flex="1" textAlign="left" color="white" fontWeight="bold">§12 - Opløsning</Box>
+                              <AccordionIcon color="white" />
+                            </AccordionButton>
+                          </h2>
+                          <AccordionPanel pb={4} color="gray.300">
+                            <Text>
+                              Beslutning om opløsning kræver 3/4 flertal på en ekstraordinær
+                              generalforsamling. Eventuel formue skal tilfalde cykelsportslige eller
+                              almennyttige formål og må ikke udbetales til medlemmerne.
+                            </Text>
+                          </AccordionPanel>
+                        </AccordionItem>
+
+                        <AccordionItem border="none" borderTop="1px" borderColor="gray.700">
+                          <h2>
+                            <AccordionButton _hover={{ bg: 'gray.800' }}>
+                              <Box flex="1" textAlign="left" color="white" fontWeight="bold">§13 - Ikrafttræden</Box>
+                              <AccordionIcon color="white" />
+                            </AccordionButton>
+                          </h2>
+                          <AccordionPanel pb={4} color="gray.300">
+                            <Text>
+                              Disse vedtægter er vedtaget på foreningens stiftende generalforsamling
+                              den 17. november 2025.
+                            </Text>
+                          </AccordionPanel>
+                        </AccordionItem>
+                      </Accordion>
+
+                      <Divider borderColor="gray.600" my={6} />
+                      <Text color="gray.400" fontSize="sm">
+                        Vedtaget på stiftende generalforsamling den 17. november 2025
                       </Text>
-                    )}
-                  </VStack>
-                </CardBody>
-              </Card>
-            ))}
-          </SimpleGrid>
-          <Text color="gray.400" mt={4} fontSize="sm">
-            Kontakt bestyrelsen via Discord
-          </Text>
-        </Box>
+                    </CardBody>
+                  </Card>
+                </Box>
 
-        {/* Vedtægter (Bylaws) Section */}
-        <Box>
-          <Heading color="white" size="lg" mb={4}>
-            Vedtægter
-          </Heading>
-          <Card bg="gray.900" borderColor="gray.700" borderWidth="1px">
-            <CardBody>
-              <Accordion allowToggle>
-                <AccordionItem border="none">
-                  <h2>
-                    <AccordionButton _hover={{ bg: 'gray.800' }}>
-                      <Box flex="1" textAlign="left" color="white" fontWeight="bold">
-                        §1 - Navn og hjemsted
-                      </Box>
-                      <AccordionIcon color="white" />
-                    </AccordionButton>
-                  </h2>
-                  <AccordionPanel pb={4} color="gray.300">
-                    <Text>
-                      Foreningens navn er Danish Zwift Racers (DZR). Foreningen er en almennyttig
-                      og non-profit online sportsforening med hjemsted på Frederiksberg og med medlemmer fra hele Danmark. Foreningen
-                      har CVR-nummer 46035771.
-                    </Text>
-                  </AccordionPanel>
-                </AccordionItem>
-
-                <AccordionItem border="none" borderTop="1px" borderColor="gray.700">
-                  <h2>
-                    <AccordionButton _hover={{ bg: 'gray.800' }}>
-                      <Box flex="1" textAlign="left" color="white" fontWeight="bold">
-                        §2 - Formål
-                      </Box>
-                      <AccordionIcon color="white" />
-                    </AccordionButton>
-                  </h2>
-                  <AccordionPanel pb={4} color="gray.300">
-                    <Text mb={2}>
-                      Foreningens formål er at fremme e-cykling som sportsgren og socialt
-                      fællesskab i Danmark. DZR skaber rammer for træning, løb og fællesskab
-                      på virtuelle cykelplatforme.
-                    </Text>
-                    <Text>
-                      Aktiviteter foregår primært online, men fysiske møder kan afholdes efter behov.
-                    </Text>
-                  </AccordionPanel>
-                </AccordionItem>
-
-                <AccordionItem border="none" borderTop="1px" borderColor="gray.700">
-                  <h2>
-                    <AccordionButton _hover={{ bg: 'gray.800' }}>
-                      <Box flex="1" textAlign="left" color="white" fontWeight="bold">
-                        §3 - Tilknytning
-                      </Box>
-                      <AccordionIcon color="white" />
-                    </AccordionButton>
-                  </h2>
-                  <AccordionPanel pb={4} color="gray.300">
-                    <Text mb={2}>
-                      Foreningen er medlem af Danmarks Cykle Union (DCU) og
-                      følger DCU&apos;s love og bestemmelser.
-                    </Text>
-                    <Text>
-                      Foreningen har ingen øvrige organisatoriske tilknytninger.
-                    </Text>
-                  </AccordionPanel>
-                </AccordionItem>
-
-                <AccordionItem border="none" borderTop="1px" borderColor="gray.700">
-                  <h2>
-                    <AccordionButton _hover={{ bg: 'gray.800' }}>
-                      <Box flex="1" textAlign="left" color="white" fontWeight="bold">
-                        §4 - Medlemskab
-                      </Box>
-                      <AccordionIcon color="white" />
-                    </AccordionButton>
-                  </h2>
-                  <AccordionPanel pb={4} color="gray.300">
-                    <Text mb={2}>
-                      Som medlem kan optages enhver person, der støtter foreningens formål.
-                      Indmeldelse sker digitalt via foreningens officielle hjemmeside
-                      www.dzrracingseries.com.
-                    </Text>
-                    <Text mb={2}>
-                      Der sondres mellem to medlemskategorier:
-                    </Text>
-                    <List spacing={2} ml={4}>
-                      <ListItem>
-                        <strong>1. Klub medlemmer:</strong> har betalt kontingent, har stemmeret
-                        og mulighed for DCU e-licens via DZR.
-                      </ListItem>
-                      <ListItem>
-                        <strong>2. Community medlemmer:</strong> deltager i foreningens
-                        Discord-server og online fællesskab, men uden stemmeret eller adgang til
-                        DCU-aktiviteter.
-                      </ListItem>
-                    </List>
-                    <Text mt={2}>
-                      Medlemskab er gyldigt, når kontingentet er betalt via foreningens hjemmeside.
-                    </Text>
-                  </AccordionPanel>
-                </AccordionItem>
-
-                <AccordionItem border="none" borderTop="1px" borderColor="gray.700">
-                  <h2>
-                    <AccordionButton _hover={{ bg: 'gray.800' }}>
-                      <Box flex="1" textAlign="left" color="white" fontWeight="bold">
-                        §5 - Udmeldelse og eksklusion
-                      </Box>
-                      <AccordionIcon color="white" />
-                    </AccordionButton>
-                  </h2>
-                  <AccordionPanel pb={4} color="gray.300">
-                    <Text mb={2}>
-                      Udmeldelse sker digitalt via foreningens hjemmeside www.dzrracingseries.com.
-                      Betalt kontingent refunderes ikke.
-                    </Text>
-                    <Text>
-                      Et medlem kan ekskluderes, hvis det handler til skade for foreningen.
-                      Eksklusion kan indbringes for den førstkommende generalforsamling til
-                      endelig afgørelse.
-                    </Text>
-                  </AccordionPanel>
-                </AccordionItem>
-
-                <AccordionItem border="none" borderTop="1px" borderColor="gray.700">
-                  <h2>
-                    <AccordionButton _hover={{ bg: 'gray.800' }}>
-                      <Box flex="1" textAlign="left" color="white" fontWeight="bold">
-                        §6 - Kontingent
-                      </Box>
-                      <AccordionIcon color="white" />
-                    </AccordionButton>
-                  </h2>
-                  <AccordionPanel pb={4} color="gray.300">
-                    <Text mb={2}>
-                      Kontingentets størrelse fastsættes én gang årligt på generalforsamlingen.
-                      Kontingent opkræves digitalt for et år ad gangen.
-                    </Text>
-                    <Text>
-                      Kontingentet dækker perioden 1. januar til 31. december og følger
-                      DCU&apos;s licensår.
-                    </Text>
-                  </AccordionPanel>
-                </AccordionItem>
-
-                <AccordionItem border="none" borderTop="1px" borderColor="gray.700">
-                  <h2>
-                    <AccordionButton _hover={{ bg: 'gray.800' }}>
-                      <Box flex="1" textAlign="left" color="white" fontWeight="bold">
-                        §7 - Generalforsamling
-                      </Box>
-                      <AccordionIcon color="white" />
-                    </AccordionButton>
-                  </h2>
-                  <AccordionPanel pb={4} color="gray.300">
-                    <Text mb={2}>
-                      Generalforsamlingen er foreningens højeste myndighed. Ordinær
-                      generalforsamling afholdes én gang årligt - digitalt eller fysisk -
-                      inden udgangen af marts.
-                    </Text>
-                    <Text mb={2}>
-                      Indkaldelse sker med mindst 14 dages varsel via e-mail og Discord.
-                    </Text>
-                    <Text mb={2} fontWeight="bold">
-                      Dagsorden:
-                    </Text>
-                    <List spacing={1} ml={4}>
-                      <ListItem>1. Valg af dirigent</ListItem>
-                      <ListItem>2. Bestyrelsens beretning</ListItem>
-                      <ListItem>3. Godkendelse af regnskab</ListItem>
-                      <ListItem>4. Fastsættelse af kontingent og budget</ListItem>
-                      <ListItem>5. Indkomne forslag</ListItem>
-                      <ListItem>6. Valg af bestyrelse</ListItem>
-                      <ListItem>7. Valg af revisor</ListItem>
-                      <ListItem>8. Eventuelt</ListItem>
-                    </List>
-                    <Text mt={2}>
-                      Forslag skal være bestyrelsen i hænde senest 7 dage før. Hvert aktivt
-                      medlem har én stemme. Beslutninger træffes ved simpelt flertal.
-                    </Text>
-                  </AccordionPanel>
-                </AccordionItem>
-
-                <AccordionItem border="none" borderTop="1px" borderColor="gray.700">
-                  <h2>
-                    <AccordionButton _hover={{ bg: 'gray.800' }}>
-                      <Box flex="1" textAlign="left" color="white" fontWeight="bold">
-                        §8 - Ekstraordinær generalforsamling
-                      </Box>
-                      <AccordionIcon color="white" />
-                    </AccordionButton>
-                  </h2>
-                  <AccordionPanel pb={4} color="gray.300">
-                    <Text>
-                      Afholdes når bestyrelsen beslutter det, eller når mindst 1/5 af de aktive
-                      medlemmer (Klub medlemmer) skriftligt kræver det. Indkaldes med samme varsel som ordinær
-                      generalforsamling.
-                    </Text>
-                  </AccordionPanel>
-                </AccordionItem>
-
-                <AccordionItem border="none" borderTop="1px" borderColor="gray.700">
-                  <h2>
-                    <AccordionButton _hover={{ bg: 'gray.800' }}>
-                      <Box flex="1" textAlign="left" color="white" fontWeight="bold">
-                        §9 - Bestyrelsen
-                      </Box>
-                      <AccordionIcon color="white" />
-                    </AccordionButton>
-                  </h2>
-                  <AccordionPanel pb={4} color="gray.300">
-                    <Text mb={2}>
-                      Bestyrelsen består af mindst 3 medlemmer valgt for ét år ad gangen.
-                      Bestyrelsen konstituerer sig selv med formand, kasserer og menigt medlem.
-                    </Text>
-                    <Text mb={2}>
-                      Møder kan afholdes digitalt. Bestyrelsen er beslutningsdygtig, når mindst
-                      halvdelen af medlemmerne deltager.
-                    </Text>
-                    <Text>
-                      Beslutninger træffes ved simpelt flertal.
-                    </Text>
-                  </AccordionPanel>
-                </AccordionItem>
-
-                <AccordionItem border="none" borderTop="1px" borderColor="gray.700">
-                  <h2>
-                    <AccordionButton _hover={{ bg: 'gray.800' }}>
-                      <Box flex="1" textAlign="left" color="white" fontWeight="bold">
-                        §10 - Økonomi og hæftelse
-                      </Box>
-                      <AccordionIcon color="white" />
-                    </AccordionButton>
-                  </h2>
-                  <AccordionPanel pb={4} color="gray.300">
-                    <Text mb={2}>
-                      Foreningens regnskabsår følger kalenderåret. Foreningen tegnes af formanden
-                      og kassereren i forening.
-                    </Text>
-                    <Text mb={2}>
-                      Medlemmer hæfter ikke personligt for foreningens forpligtelser - foreningen
-                      hæfter alene med sin egen formue.
-                    </Text>
-                    <Text>
-                      Regnskabet revideres af en kritisk revisor valgt af generalforsamlingen.
-                    </Text>
-                  </AccordionPanel>
-                </AccordionItem>
-
-                <AccordionItem border="none" borderTop="1px" borderColor="gray.700">
-                  <h2>
-                    <AccordionButton _hover={{ bg: 'gray.800' }}>
-                      <Box flex="1" textAlign="left" color="white" fontWeight="bold">
-                        §11 - Vedtægtsændringer
-                      </Box>
-                      <AccordionIcon color="white" />
-                    </AccordionButton>
-                  </h2>
-                  <AccordionPanel pb={4} color="gray.300">
-                    <Text>
-                      Ændringer af vedtægterne kræver, at 2/3 af de afgivne stemmer på en
-                      generalforsamling stemmer for.
-                    </Text>
-                  </AccordionPanel>
-                </AccordionItem>
-
-                <AccordionItem border="none" borderTop="1px" borderColor="gray.700">
-                  <h2>
-                    <AccordionButton _hover={{ bg: 'gray.800' }}>
-                      <Box flex="1" textAlign="left" color="white" fontWeight="bold">
-                        §12 - Opløsning
-                      </Box>
-                      <AccordionIcon color="white" />
-                    </AccordionButton>
-                  </h2>
-                  <AccordionPanel pb={4} color="gray.300">
-                    <Text>
-                      Beslutning om opløsning kræver 3/4 flertal på en ekstraordinær
-                      generalforsamling. Eventuel formue skal tilfalde cykelsportslige eller
-                      almennyttige formål og må ikke udbetales til medlemmerne.
-                    </Text>
-                  </AccordionPanel>
-                </AccordionItem>
-
-                <AccordionItem border="none" borderTop="1px" borderColor="gray.700">
-                  <h2>
-                    <AccordionButton _hover={{ bg: 'gray.800' }}>
-                      <Box flex="1" textAlign="left" color="white" fontWeight="bold">
-                        §13 - Ikrafttræden
-                      </Box>
-                      <AccordionIcon color="white" />
-                    </AccordionButton>
-                  </h2>
-                  <AccordionPanel pb={4} color="gray.300">
-                    <Text>
-                      Disse vedtægter er vedtaget på foreningens stiftende generalforsamling
-                      den 17. november 2025.
-                    </Text>
-                  </AccordionPanel>
-                </AccordionItem>
-              </Accordion>
-
-              <Divider borderColor="gray.600" my={6} />
-
-              <VStack align="start" spacing={2}>
-                <Text color="gray.400" fontSize="sm">
-                  Vedtaget på stiftende generalforsamling den 17. november 2025
-                </Text>
               </VStack>
-            </CardBody>
-          </Card>
-        </Box>
+            </AccordionPanel>
+          </AccordionItem>
+        </Accordion>
 
-        {/* Contact Section */}
-        <Box textAlign="center" py={4}>
-          <Text color="gray.400" fontSize="sm">
+        {/* Zone 6 — Minimal footer */}
+        <Box borderTop="1px solid" borderColor="gray.700" pt={6} textAlign="center">
+          <Text color="gray.500" fontSize="sm">
             For spørgsmål eller mere information, kontakt os via Discord.
           </Text>
         </Box>
+
       </VStack>
     </Container>
   );
 }
-


### PR DESCRIPTION
Replaces the flat single-box layout with four distinct sections:
- Zone 1: Hero (badge + heading + subtext, unchanged content)
- Zone 2: 5 benefit cards with icons and red top-border accent
- Zone 3: Visual 3-step stepper (Discord → Payment → Zwift ID)
- Zone 4: Prominent price callout + pulsing full-width CTA button

No new dependencies — reuses existing react-icons (fa, fa6, md),
Chakra UI components already used elsewhere in the project
(SimpleGrid, Circle, Flex, keyframes), and the pulseShadow animation
pattern from HeroSection.tsx.

https://claude.ai/code/session_01JQpMAjR5ZtGvroY55fwKoe