### PR TITLE
Redesign benefit boxes with horizontal icon-left cards and stat-style pillars

### DIFF
--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -38,20 +38,26 @@ interface BenefitCardProps {
 
 function BenefitCard({ icon, heading, text }: BenefitCardProps) {
   return (
-    <Box
+    <HStack
+      align="start"
+      spacing={4}
+      p={4}
       bg="gray.900"
       borderRadius="md"
-      borderTop="2px solid #ad1a2d"
-      p={4}
+      borderLeft="3px solid #ad1a2d"
     >
-      <Icon as={icon} boxSize={6} color="#ad1a2d" mb={2} />
-      <Text color="white" fontWeight="semibold" fontSize="sm" mb={1}>
-        {heading}
-      </Text>
-      <Text color="gray.400" fontSize="sm">
-        {text}
-      </Text>
-    </Box>
+      <Circle size="40px" bg="#ad1a2d" flexShrink={0}>
+        <Icon as={icon} color="white" boxSize={4} />
+      </Circle>
+      <Box>
+        <Text color="white" fontWeight="semibold" fontSize="sm" mb={1}>
+          {heading}
+        </Text>
+        <Text color="gray.400" fontSize="sm">
+          {text}
+        </Text>
+      </Box>
+    </HStack>
   )
 }
 

--- a/app/members-zone/about/page.tsx
+++ b/app/members-zone/about/page.tsx
@@ -14,6 +14,7 @@ import {
   Card,
   CardBody,
   CardHeader,
+  Circle,
   Container,
   Divider,
   Heading,
@@ -94,19 +95,25 @@ export default function AboutPage() {
 
         {/* Zone 2 — Three benefit pillars */}
         <SimpleGrid columns={{ base: 1, md: 3 }} spacing={4}>
-          <Box bg="gray.900" borderRadius="md" borderTop="2px solid #ad1a2d" p={5}>
-            <Icon as={FaTrophy} boxSize={6} color="#ad1a2d" mb={2} />
-            <Heading size="sm" color="white" mb={1}>Løb & Racing</Heading>
+          <Box textAlign="center" p={6} bg="gray.900" borderRadius="lg">
+            <Circle size="56px" bg="#ad1a2d" mx="auto" mb={4}>
+              <Icon as={FaTrophy} color="white" boxSize={6} />
+            </Circle>
+            <Heading size="md" color="white" mb={2}>Løb & Racing</Heading>
             <Text color="gray.400" fontSize="sm">Organiserede løb, DCU Forårsliga og holdmiljø på Zwift</Text>
           </Box>
-          <Box bg="gray.900" borderRadius="md" borderTop="2px solid #ad1a2d" p={5}>
-            <Icon as={FaDiscord} boxSize={6} color="#ad1a2d" mb={2} />
-            <Heading size="sm" color="white" mb={1}>Discord Fællesskab</Heading>
+          <Box textAlign="center" p={6} bg="gray.900" borderRadius="lg">
+            <Circle size="56px" bg="#ad1a2d" mx="auto" mb={4}>
+              <Icon as={FaDiscord} color="white" boxSize={6} />
+            </Circle>
+            <Heading size="md" color="white" mb={2}>Discord Fællesskab</Heading>
             <Text color="gray.400" fontSize="sm">Aktiv community med koordinering af hold, events og kommunikation</Text>
           </Box>
-          <Box bg="gray.900" borderRadius="md" borderTop="2px solid #ad1a2d" p={5}>
-            <Icon as={MdDirectionsBike} boxSize={6} color="#ad1a2d" mb={2} />
-            <Heading size="sm" color="white" mb={1}>Træning</Heading>
+          <Box textAlign="center" p={6} bg="gray.900" borderRadius="lg">
+            <Circle size="56px" bg="#ad1a2d" mx="auto" mb={4}>
+              <Icon as={MdDirectionsBike} color="white" boxSize={6} />
+            </Circle>
+            <Heading size="md" color="white" mb={2}>Træning</Heading>
             <Text color="gray.400" fontSize="sm">Strukturerede træningspas og zone 2-workouts for alle niveauer</Text>
           </Box>
         </SimpleGrid>


### PR DESCRIPTION
- Join page: replace top-bordered vertical cards with horizontal HStack layout —
  red Circle icon on left, text on right, left-border accent
- About page: upgrade 3 pillars to centered stat-style with larger red Circle icons

https://claude.ai/code/session_01KbrFLba4qH3RuM9vJkcmDQ