### PR TITLE
Shorten Discord community button text on about page

### DIFF
--- a/app/members-zone/about/page.tsx
+++ b/app/members-zone/about/page.tsx
@@ -167,7 +167,7 @@ export default function AboutPage() {
                 fontSize="md"
                 rightIcon={<FiArrowRight size="1.2em" />}
               >
-                Bliv klubmedlem
+                Klubmedlem
               </Button>
               <Button
                 as="a"

--- a/app/members-zone/about/page.tsx
+++ b/app/members-zone/about/page.tsx
@@ -185,7 +185,7 @@ export default function AboutPage() {
                 fontSize="md"
                 leftIcon={<FaDiscord size="1.2em" />}
               >
-                Bliv Community medlem (gratis)
+                Community Medlem (gratis)
               </Button>
             </Stack>
           )}


### PR DESCRIPTION
Remove "Bliv" prefix from "Bliv Community Medlem (gratis)" to
"Community Medlem (gratis)" so it fits on one line on mobile.

https://claude.ai/code/session_01PXR4Jt691iTDz2AwAhEBgz